### PR TITLE
Add library.json

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,10 @@
+{
+    "name": "bowler-rpc-arduino",
+    "version": "v0.1.0",
+    "keywords": "bowler, rpc, esp32, teensy, wifi, hid",
+    "description": "An implementation of the Bowler RPC for Arduino.",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/CommonWealthRobotics/bowler-rpc-arduino.git"
+    }
+}


### PR DESCRIPTION
### Description of the Change

This PR adds the `library.json` file that PlatformIO needs to register the library.

### Motivation

This should be a registered library.

### Verification Process

This was not verified.

### Applicable Issues

None.
